### PR TITLE
ledcSetup and ledcAttachPin deprecated

### DIFF
--- a/src/Buzzer.cpp
+++ b/src/Buzzer.cpp
@@ -57,8 +57,7 @@ void Buzzer::resume()
 void Buzzer::_init()
 {
 #ifdef ESP32
-    ledcSetup(_channel, 2000, 8); // setup beeper at 2000, maybe lower?
-    ledcAttachPin(_pin, _channel); 
+    ledcAttach(_pin, 2000, 8); // setup beeper at 2000, maybe lower?
 #endif
 }
 


### PR DESCRIPTION
Fix for a breaking change in ESP32 Arduino core version 3.0

The new version replaces them with `ledcAttach`.

I found only one reference to that, which I corrected. In my project it seems to work fine again!